### PR TITLE
Add `tldextract` version `3.2.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,36 +11,33 @@ source:
 
 build:
   noarch: python
-  entry_points:
-    - tldextract = tldextract.cli:main
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - tldextract = tldextract.cli:main
 
 requirements:
   host:
+    - python
     - pip
-    - python >=3.6
     - setuptools
     - setuptools_scm
-
+    - wheel
   run:
-    - python >=3.6
-    - setuptools
+    - python >=3.7
+    - filelock >=3.0.8
     - idna
     - requests >=2.1.0
     - requests-file >=1.4
-    - filelock
 
 test:
   imports:
     - tldextract
-
-  commands:
-    - tldextract --help
-    - pip check
-
   requires:
     - pip
+  commands:
+    - pip check    
+    - tldextract --help
 
 about:
   home: https://github.com/john-kurkowski/tldextract
@@ -49,6 +46,7 @@ about:
   license_family: BSD
   summary: Accurately separate the TLD from the registered domain andsubdomains of a URL, using the Public Suffix List.
   dev_url: https://github.com/john-kurkowski/tldextract
+  doc_url: https://github.com/john-kurkowski/tldextract/blob/master/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/john-kurkowski/tldextract/blob/3.2.0/CHANGELOG.md
License: https://github.com/john-kurkowski/tldextract/blob/3.2.0/LICENSE
Upstream setup.py: https://github.com/john-kurkowski/tldextract/blob/3.2.0/setup.py

Actions:
1. Add wheel in host
2. Update pinning for python and filelock in run
3. Add doc_url